### PR TITLE
Updating wordBase object to add speaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+
+- Updated the `wordBase` type to include an optional `speaker` property.
+- Updated the documentation for the speaker property of the `utterance` type. 
+
 ---
 
 ## [1.1.0]

--- a/src/types/utterance.ts
+++ b/src/types/utterance.ts
@@ -29,7 +29,8 @@ export type Utterance = {
    */
   words: Array<WordBase>;
   /**
-   * Integer indicating the speaker who is saying the word being processed.
+   * Integer indicating the predicted speaker of the majority of words
+   * in the utterance who is saying the words being processed.
    */
   speaker?: number;
   /**

--- a/src/types/wordBase.ts
+++ b/src/types/wordBase.ts
@@ -4,4 +4,5 @@ export type WordBase = {
   end: number;
   confidence: number;
   punctuated_word?: string;
+  speaker?: number;
 };


### PR DESCRIPTION
- Updated the `wordBase` type to include an optional `speaker` property.
- Updated the documentation for the speaker property of the `utterance` type. 