### PR TITLE
Added the ability to create temporary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+
+- Updated the `keys.create` function to allow new `expirationDate` or `timeToLive`
+values. These are optional and one at most can be provided. Providing both will
+throw an error.
+
 ---
 
 ## [1.1.0]

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -38,18 +38,29 @@ export class Keys {
    * @param projectId Unique identifier of the project to create an API key under
    * @param comment Comment to describe the key
    * @param scopes Permission scopes associated with the API key
+   * @param expirationDate Date on which the key you would like to create should expire. 
+   * @param timeToLive Length of time (in seconds) during which the key you would like to create will remain valid.
    */
   async create(
     projectId: string,
     comment: string,
-    scopes: Array<string>
+    scopes: Array<string>,
+    expirationDate?: Date,
+    timeToLive?: number
   ): Promise<Key> {
+
+    /** Throw an error if the user provided both expirationDate and timeToLive */
+    if (expirationDate !== undefined &&
+        timeToLive !== undefined) {
+          throw new Error('Please provide expirationDate or timeToLive or neither. Providing both is not allowed.')
+        }
+
     return _request<Key>(
       "POST",
       this._credentials,
       this._apiUrl,
       `${this.apiPath}/${projectId}/keys`,
-      JSON.stringify({ comment, scopes })
+      JSON.stringify({ comment, scopes, expiration_date: expirationDate, time_to_live_in_seconds: timeToLive })
     );
   }
 

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -1,5 +1,5 @@
 import { _request } from "./httpRequest";
-import { KeyResponse, Key } from "./types";
+import { CreateKeyOptions, KeyResponse, Key } from "./types";
 
 export class Keys {
   constructor(private _credentials: string, private _apiUrl: string) {}
@@ -38,29 +38,40 @@ export class Keys {
    * @param projectId Unique identifier of the project to create an API key under
    * @param comment Comment to describe the key
    * @param scopes Permission scopes associated with the API key
-   * @param expirationDate Date on which the key you would like to create should expire. 
-   * @param timeToLive Length of time (in seconds) during which the key you would like to create will remain valid.
+   * @param options Optional options used when creating API keys
    */
   async create(
     projectId: string,
     comment: string,
     scopes: Array<string>,
-    expirationDate?: Date,
-    timeToLive?: number
+    options?: CreateKeyOptions
   ): Promise<Key> {
-
     /** Throw an error if the user provided both expirationDate and timeToLive */
-    if (expirationDate !== undefined &&
-        timeToLive !== undefined) {
-          throw new Error('Please provide expirationDate or timeToLive or neither. Providing both is not allowed.')
-        }
+    if (
+      options &&
+      options.expirationDate !== undefined &&
+      options.timeToLive !== undefined
+    ) {
+      throw new Error(
+        "Please provide expirationDate or timeToLive or neither. Providing both is not allowed."
+      );
+    }
 
     return _request<Key>(
       "POST",
       this._credentials,
       this._apiUrl,
       `${this.apiPath}/${projectId}/keys`,
-      JSON.stringify({ comment, scopes, expiration_date: expirationDate, time_to_live_in_seconds: timeToLive })
+      JSON.stringify({
+        comment,
+        scopes,
+        expiration_date:
+          options && options.expirationDate
+            ? options.expirationDate
+            : undefined,
+        time_to_live_in_seconds:
+          options && options.timeToLive ? options.timeToLive : undefined,
+      })
     );
   }
 

--- a/src/types/createKeyOptions.ts
+++ b/src/types/createKeyOptions.ts
@@ -1,0 +1,13 @@
+/**
+ * Optional options used when creating an API key
+ */
+export type CreateKeyOptions = {
+  /**
+   * Date on which the key you would like to create should expire.
+   */
+  expirationDate?: Date;
+  /**
+   * Length of time (in seconds) during which the key you would like to create will remain valid.
+   */
+  timeToLive?: number;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./channel";
+export * from "./createKeyOptions";
 export * from "./hit";
 export * from "./key";
 export * from "./keyResponse";

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -53,6 +53,24 @@ describe("Key tests", () => {
     });
   });
 
+  it("Throws an exception if both expirationDate and timeToLive are provided", function () {
+    const expectedError = `Please provide expirationDate or timeToLive or neither. Providing both is not allowed.`;
+    nock(`https://${fakeUrl}`)
+      .post(`/v1/projects/${fakeProjectId}/keys`)
+      .reply(200, mockKey);
+
+      keys.create(fakeProjectId, "test Comment", ["member"], new Date(), 30).then((response) => {
+        response.should.deep.eq(mockKey);
+        requestStub.calledOnce.should.eq(true);
+      })
+      .then(() => {
+        assert.equal(1, 2);
+      })
+      .catch((err) => {
+        assert.equal(err, expectedError);
+      });     
+  });
+
   it("Delete resolves", function () {
     nock(`https://${fakeUrl}`)
       .delete(`/v1/projects/${fakeProjectId}/keys/${fakeKeyId}`)

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -59,7 +59,12 @@ describe("Key tests", () => {
       .post(`/v1/projects/${fakeProjectId}/keys`)
       .reply(200, mockKey);
 
-      keys.create(fakeProjectId, "test Comment", ["member"], new Date(), 30).then((response) => {
+    keys
+      .create(fakeProjectId, "test Comment", ["member"], {
+        expirationDate: new Date(),
+        timeToLive: 30,
+      })
+      .then((response) => {
         response.should.deep.eq(mockKey);
         requestStub.calledOnce.should.eq(true);
       })
@@ -68,7 +73,49 @@ describe("Key tests", () => {
       })
       .catch((err) => {
         assert.equal(err, expectedError);
-      });     
+      });
+  });
+
+  it("Does not throw if only timeToLive is provided as an option", function () {
+    nock(`https://${fakeUrl}`)
+      .post(`/v1/projects/${fakeProjectId}/keys`)
+      .reply(200, mockKey);
+
+    keys
+      .create(fakeProjectId, "test Comment", ["member"], {
+        timeToLive: 30,
+      })
+      .then((response) => {
+        response.should.deep.eq(mockKey);
+        requestStub.calledOnce.should.eq(true);
+      })
+      .then(() => {
+        assert.equal(1, 1);
+      })
+      .catch((err) => {
+        assert.equal(1, 2);
+      });
+  });
+
+  it("Does not throw if only expirationDate is provided as an option", function () {
+    nock(`https://${fakeUrl}`)
+      .post(`/v1/projects/${fakeProjectId}/keys`)
+      .reply(200, mockKey);
+
+    keys
+      .create(fakeProjectId, "test Comment", ["member"], {
+        expirationDate: new Date(),
+      })
+      .then((response) => {
+        response.should.deep.eq(mockKey);
+        requestStub.calledOnce.should.eq(true);
+      })
+      .then(() => {
+        assert.equal(1, 1);
+      })
+      .catch((err) => {
+        assert.equal(1, 2);
+      });
   });
 
   it("Delete resolves", function () {


### PR DESCRIPTION
Updated the `keys.create` function to allow new `expirationDate` or `timeToLive` values. These are optional and one at most can be provided. Providing both will throw an error.