### PR TITLE
Fixing real-time socket close bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.1]
+
+### Fixed
+
+- Fixed a bug that caused real-time transcriptions to not close correctly. This
+would result in the user not received the final transcription.
+
 ## [1.2.0]
 
 ### Updated
@@ -137,7 +144,9 @@ throw an error.
 
 ---
 
-[unreleased]: https://github.com/deepgram/node-sdk/compare/1.1.0...HEAD
+[unreleased]: https://github.com/deepgram/node-sdk/compare/1.2.1...HEAD
+[1.2.1]: https://github.com/deepgram/node-sdk/compare/1.2.0...1.2.1
+[1.2.0]: https://github.com/deepgram/node-sdk/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/deepgram/node-sdk/compare/1.0.3...1.1.0
 [1.0.3]: https://github.com/deepgram/node-sdk/compare/1.0.2...1.0.3
 [1.0.2]: https://github.com/deepgram/node-sdk/compare/1.0.0...1.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepgram/sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepgram/sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "An SDK for the Deepgram automated speech recognition platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transcription/liveTranscription.ts
+++ b/src/transcription/liveTranscription.ts
@@ -71,6 +71,6 @@ export class LiveTranscription extends EventEmitter {
    * the websocket connection when transcription is finished
    */
   public finish(): void {
-    this._socket.close(1000);
+    this._socket.send(new Uint8Array(0));
   }
 }


### PR DESCRIPTION
Our `finish` function was not sending a final message that would tell Deepgram to finalize the stream. This would result in users not getting the final transcript.

Closes #23 